### PR TITLE
changes to graph on distributions vignette

### DIFF
--- a/vignettes/distributions.Rmd
+++ b/vignettes/distributions.Rmd
@@ -38,7 +38,7 @@ library(ssdtools)
 library(ggplot2)
 
 set.seed(7)
-ssd_plot_cdf(ssd_match_moments())
+ssd_plot_cdf(ssd_match_moments(meanlog = 2,sdlog = 2))
 ```
 
 ### Log-normal distribution


### PR DESCRIPTION
I tried changing the meanlog and sdlog to 2 and it shows the distinctness of the tails a bit better. 