### PR TITLE
split tests so match filenames in R

### DIFF
--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -1,0 +1,22 @@
+#    Copyright 2015 Province of British Columbia
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+test_that("autoplot", {
+  setup(pdf(tempfile(fileext = ".pdf")))
+  teardown(dev.off())
+  
+  expect_is(ggplot2::autoplot(boron_lnorm), "ggplot")
+  expect_is(ggplot2::autoplot(boron_dists), "ggplot")
+  expect_is(ggplot2::autoplot(fluazinam_lnorm), "ggplot")
+})

--- a/tests/testthat/test-burrIII2.R
+++ b/tests/testthat/test-burrIII2.R
@@ -170,4 +170,10 @@ test_that("deprecated dburrIII2", {
   expect_error(ssd_fit_dists(ssdtools::boron_data, dist = c("llogis", "burrIII2")), "Distributions 'llog', 'burrIII2' and 'llogis' are identical. Please just use 'llogis'.")
 })
 
-
+test_that("burrIII2", {
+  rlang::scoped_options(lifecycle_verbosity = "quiet")
+  dists <- ssd_fit_dists(boron_data[1:6, ], dists = c("burrIII2", "gamma", "lnorm"))
+  expect_identical(names(dists), c("burrIII2", "gamma", "lnorm"))
+  expect_equal(coef(dists$burrIII2), c(locationlog = 1.8357959974758, scalelog = 0.547213918037133
+  ))
+})

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -52,14 +52,6 @@ test_that("fit_dists", {
   expect_identical(names(coef), dist_names)
 })
 
-test_that("burrIII2", {
-  rlang::scoped_options(lifecycle_verbosity = "quiet")
-  dists <- ssd_fit_dists(boron_data[1:6, ], dists = c("burrIII2", "gamma", "lnorm"))
-  expect_identical(names(dists), c("burrIII2", "gamma", "lnorm"))
-  expect_equal(coef(dists$burrIII2), c(locationlog = 1.8357959974758, scalelog = 0.547213918037133
-  ))
-})
-
 test_that("fit_dist", {
   skip_if_not(capabilities("long.double"))
   

--- a/tests/testthat/test-plot-cdf.R
+++ b/tests/testthat/test-plot-cdf.R
@@ -12,27 +12,14 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-test_that("plot geoms", {
+test_that("ssd_plot_cdf", {
   setup(pdf(tempfile(fileext = ".pdf")))
   teardown(dev.off())
-  data <- boron_data
-  data$yintercept <- 0.10
-  gp <- ggplot(boron_data, aes(x = Conc)) +
-    stat_ssd() +
-    geom_ssd() +
-    geom_hcintersect(xintercept = 1, yintercept = 0.05) +
-    geom_hcintersect(yintercept = 0.05) +
-    geom_xribbon(
-      data = boron_pred,
-      aes_string(xmin = "lcl", xmax = "ucl", y = "percent")
-    )
-  expect_is(gp, "ggplot")
+  
+  expect_is(ssd_plot_cdf(boron_lnorm), "ggplot")
+  expect_is(ssd_plot_cdf(boron_dists), "ggplot")
+  fluazinam_lnorm$censdata$right[3] <- fluazinam_lnorm$censdata$left[3] * 1.5
+  fluazinam_lnorm$censdata$left[5] <- NA
+  expect_is(ssd_plot_cdf(fluazinam_lnorm), "ggplot")
+  expect_is(ssd_plot_cdf(fluazinam_dists), "ggplot")
 })
-
-test_that("plot", {
-  setup(pdf(tempfile(fileext = ".pdf")))
-  teardown(dev.off())
-
-  expect_silent(plot(boron_dists))
-})
-

--- a/tests/testthat/test-plot-cf.R
+++ b/tests/testthat/test-plot-cf.R
@@ -12,27 +12,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-test_that("plot geoms", {
+test_that("cfplot", {
   setup(pdf(tempfile(fileext = ".pdf")))
   teardown(dev.off())
-  data <- boron_data
-  data$yintercept <- 0.10
-  gp <- ggplot(boron_data, aes(x = Conc)) +
-    stat_ssd() +
-    geom_ssd() +
-    geom_hcintersect(xintercept = 1, yintercept = 0.05) +
-    geom_hcintersect(yintercept = 0.05) +
-    geom_xribbon(
-      data = boron_pred,
-      aes_string(xmin = "lcl", xmax = "ucl", y = "percent")
-    )
-  expect_is(gp, "ggplot")
+  
+  expect_silent(ssd_plot_cf(boron_data))
 })
-
-test_that("plot", {
-  setup(pdf(tempfile(fileext = ".pdf")))
-  teardown(dev.off())
-
-  expect_silent(plot(boron_dists))
-})
-

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -55,15 +55,6 @@ test_that("ssd_plot_cdf", {
   expect_is(ssd_plot_cdf(fluazinam_dists), "ggplot")
 })
 
-test_that("autoplot", {
-  setup(pdf(tempfile(fileext = ".pdf")))
-  teardown(dev.off())
-
-  expect_is(ggplot2::autoplot(boron_lnorm), "ggplot")
-  expect_is(ggplot2::autoplot(boron_dists), "ggplot")
-  expect_is(ggplot2::autoplot(fluazinam_lnorm), "ggplot")
-})
-
 test_that("ssd_plot", {
   setup(pdf(tempfile(fileext = ".pdf")))
   teardown(dev.off())

--- a/tests/testthat/test-ssd-plot.R
+++ b/tests/testthat/test-ssd-plot.R
@@ -12,27 +12,15 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-test_that("plot geoms", {
+test_that("ssd_plot", {
   setup(pdf(tempfile(fileext = ".pdf")))
   teardown(dev.off())
-  data <- boron_data
-  data$yintercept <- 0.10
-  gp <- ggplot(boron_data, aes(x = Conc)) +
-    stat_ssd() +
-    geom_ssd() +
-    geom_hcintersect(xintercept = 1, yintercept = 0.05) +
-    geom_hcintersect(yintercept = 0.05) +
-    geom_xribbon(
-      data = boron_pred,
-      aes_string(xmin = "lcl", xmax = "ucl", y = "percent")
-    )
-  expect_is(gp, "ggplot")
+  
+  expect_is(ssd_plot(boron_data, boron_pred), "ggplot")
+  expect_is(ssd_plot(boron_data, boron_pred, ribbon = TRUE, label = "Species"), "ggplot")
+  
+  data(fluazinam, package = "fitdistrplus")
+  expect_is(ssd_plot(fluazinam, fluazinam_pred,
+                     left = "left", right = "right"
+  ), "ggplot")
 })
-
-test_that("plot", {
-  setup(pdf(tempfile(fileext = ".pdf")))
-  teardown(dev.off())
-
-  expect_silent(plot(boron_dists))
-})
-


### PR DESCRIPTION
This tidying of test code file names was funded by ECCC (it is not sufficiently significant to warrant a copyright notice in the code itself)

Fixes #66
