### PR TITLE
Fix issue with rounding of x-axis concentration labels.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -13,20 +13,29 @@
 #    limitations under the License.
 
 #' Comma and Significance Formatter
+#' 
+#' By default the numeric vectors are first rounded to three significant figures.
+#' Then scales::commas is only applied to values greater than or equal to 1000
+#' to ensure that labels are permitted to have different numbers of decimal places.
 #'
-#' @inheritParams scales::comma
-#' @inheritParams base::signif
+#' @param x A numeric vector to format.
+#' @param digits A whole number specifying the number of significant figures
+#' @param ... Additional arguments passed to [scales::comma].
 #'
-#' @return A function that returns a character vector.
-#' @seealso [scales::comma()]
+#' @return A character vector.
 #' @export
 #'
 #' @examples
-#' comma_signif(1199)
-comma_signif <- function(x, digits = 1, ...) {
+#' comma_signif(c(0.1, 1, 10, 1000))
+#' scales::comma(c(0.1, 1, 10, 1000))
+comma_signif <- function(x, digits = 3, ...) {
+  if(vld_used(...)) {
+    deprecate_soft("0.3.3", "comma_signif(...)")
+  }
+
   x <- signif(x, digits = digits)
   y <- as.character(x)
-  bol <- !is.na(x) & as.numeric(x) >= 1
+  bol <- !is.na(x) & as.numeric(x) >= 1000
   y[bol] <- scales::comma(x[bol], ...)
   y
 }

--- a/man/comma_signif.Rd
+++ b/man/comma_signif.Rd
@@ -4,24 +4,24 @@
 \alias{comma_signif}
 \title{Comma and Significance Formatter}
 \usage{
-comma_signif(x, digits = 1, ...)
+comma_signif(x, digits = 3, ...)
 }
 \arguments{
 \item{x}{A numeric vector to format.}
 
-\item{digits}{Deprecated, use \code{accuracy} instead.}
+\item{digits}{A whole number specifying the number of significant figures}
 
-\item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
+\item{...}{Additional arguments passed to \link[scales:label_number]{scales::comma}.}
 }
 \value{
-A function that returns a character vector.
+A character vector.
 }
 \description{
-Comma and Significance Formatter
+By default the numeric vectors are first rounded to three significant figures.
+Then scales::commas is only applied to values greater than or equal to 1000
+to ensure that labels are permitted to have different numbers of decimal places.
 }
 \examples{
-comma_signif(1199)
-}
-\seealso{
-\code{\link[scales:label_number]{scales::comma()}}
+comma_signif(c(0.1, 1, 10, 1000))
+scales::comma(c(0.1, 1, 10, 1000))
 }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -19,21 +19,45 @@ test_that("utils", {
   expect_true(is.fitdistcens(fluazinam_lnorm))
   expect_true(is.fitdistscens(fluazinam_dists))
   expect_true(is.fitdistcens(fluazinam_dists[[1]]))
-
+  
   expect_identical(nobs(boron_lnorm), 28L)
   expect_identical(nobs(boron_dists), nobs(boron_lnorm))
   expect_identical(nobs(fluazinam_lnorm), NA_integer_)
   expect_identical(nobs(fluazinam_dists), NA_integer_)
-
+  
   expect_identical(npars(boron_lnorm), 2L)
   expect_identical(npars(boron_dists), c(
     llogis = 2L, gamma = 2L, lnorm = 2L
   ))
   expect_identical(npars(fluazinam_lnorm), 2L)
   expect_identical(npars(fluazinam_dists), c(llogis = 2L, gamma = 2L, lnorm = 2L))
-  expect_identical(
-    comma_signif(c(0.0191, 1, NA, 1111)),
-    c("0.02", "1", NA, "1,000")
-  )
+  
   expect_equal(ssd_ecd(1:10), seq(0.05, 0.95, by = 0.1))
+})
+
+test_that("comma_signif", {
+  expect_identical(
+    comma_signif(c(0.0191, 1, NA, 177, 1111)),
+    c("0.0191", "1", NA, "177", "1,110")
+  )
+  expect_identical(
+    comma_signif(c(0.0191, 1, NA, 177, 1111), digits = 1),
+    c("0.02", "1", NA, "200", "1,000")
+  )
+  expect_identical(
+    comma_signif(c(0.1, 1)),
+    c("0.1", "1")
+  )
+  expect_identical(
+    comma_signif(c(0.1, 1, 10)),
+    c("0.1", "1", "10")
+  )
+  expect_identical(
+    comma_signif(c(0.1, 1, 10, 1000)),
+    c("0.1", "1", "10", "1,000")
+  )
+  expect_identical(
+    comma_signif(c(0.55555, 55555)),
+    c("0.556", "55,600")
+  )
 })


### PR DESCRIPTION
`comma_signif()` now rounds to 3 significant digits by default