### PR TITLE
 Issue warning if attempting to model average with censored data and different number of parameters

### DIFF
--- a/R/gof.R
+++ b/R/gof.R
@@ -71,7 +71,7 @@ ssd_gof.fitdists <- function(x, pvalue = FALSE, ...) {
   glance <- glance(x)
   glance$bic <- -2 * glance$log_lik + log(glance$nobs) * glance$npars
 
-  if (glance$nobs[1] < 8) {
+  if (is.na(glance$nobs[1] || glance$nobs[1] < 8)) {
     glance$ad <- NA_real_
     glance$ks <- NA_real_
     glance$cvm <- NA_real_

--- a/R/hcp.R
+++ b/R/hcp.R
@@ -335,6 +335,9 @@ hcp_weighted <- function(hcp, level, samples, min_pboot) {
       hc = hc, save_to = save_to, samples = samples, fun = fun)
     return(hcp)
   }
+  if(.is_censored(censoring) & !identical_parameters(x)) {
+     wrn("Model averaged estimates cannot be calculated for censored data when the distributions have different numbers of parameters.")
+  }
   
   if(multi_ci) {
     hcp <- .ssd_hcp_multi(

--- a/R/internal.R
+++ b/R/internal.R
@@ -12,6 +12,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+identical_parameters <- function(x){
+  length(unique(npars(x))) < 2
+}
+
 probs <- function(level) {
   probs <- (1 - level) / 2
   c(probs, 1 - probs)

--- a/tests/testthat/_snaps/gof/gof2.csv
+++ b/tests/testthat/_snaps/gof/gof2.csv
@@ -1,0 +1,3 @@
+dist,ad,ks,cvm,aic,aicc,bic,delta,weight
+llogis,NA,NA,NA,225.993,NA,NA,2.187,0.251
+lnorm,NA,NA,NA,223.806,NA,NA,0,0.749

--- a/tests/testthat/_snaps/gof/gof5.csv
+++ b/tests/testthat/_snaps/gof/gof5.csv
@@ -1,0 +1,3 @@
+dist,ad,ks,cvm,aic,aicc,bic,delta,weight
+llogis_llogis,NA,NA,NA,224.934,NA,NA,1.219,0.352
+lnorm_lnorm,NA,NA,NA,223.714,NA,NA,0,0.648

--- a/tests/testthat/_snaps/gof/gof_pvalue_mixture.csv
+++ b/tests/testthat/_snaps/gof/gof_pvalue_mixture.csv
@@ -1,2 +1,0 @@
-dist,ad,ks,cvm,aic,aicc,bic,delta,weight
-llogis_llogis,0.933559,0.8758,0.942315,241.79,244.517,248.451,0,1

--- a/tests/testthat/_snaps/gof/gof_statistic2.csv
+++ b/tests/testthat/_snaps/gof/gof_statistic2.csv
@@ -1,0 +1,3 @@
+dist,ad,ks,cvm,aic,aicc,bic,delta,weight
+llogis,NA,NA,NA,225.993,NA,NA,2.187,0.251
+lnorm,NA,NA,NA,223.806,NA,NA,0,0.749

--- a/tests/testthat/_snaps/gof/gof_statistic5.csv
+++ b/tests/testthat/_snaps/gof/gof_statistic5.csv
@@ -1,0 +1,3 @@
+dist,ad,ks,cvm,aic,aicc,bic,delta,weight
+llogis_llogis,NA,NA,NA,224.934,NA,NA,1.219,0.352
+lnorm_lnorm,NA,NA,NA,223.714,NA,NA,0,0.648

--- a/tests/testthat/_snaps/gof/gof_statistic_mixture.csv
+++ b/tests/testthat/_snaps/gof/gof_statistic_mixture.csv
@@ -1,2 +1,0 @@
-dist,ad,ks,cvm,aic,aicc,bic,delta,weight
-llogis_llogis,0.305358,0.111714,0.0387871,241.79,244.517,248.451,0,1

--- a/tests/testthat/_snaps/gof/gof_statisticn.csv
+++ b/tests/testthat/_snaps/gof/gof_statisticn.csv
@@ -1,0 +1,3 @@
+dist,ad,ks,cvm,aic,aicc,bic,delta,weight
+llogis,NA,NA,NA,225.993,NA,NA,NA,NA
+lnorm_lnorm,NA,NA,NA,223.714,NA,NA,NA,NA

--- a/tests/testthat/_snaps/gof/gofn.csv
+++ b/tests/testthat/_snaps/gof/gofn.csv
@@ -1,0 +1,3 @@
+dist,ad,ks,cvm,aic,aicc,bic,delta,weight
+llogis,NA,NA,NA,225.993,NA,NA,NA,NA
+lnorm_lnorm,NA,NA,NA,223.714,NA,NA,NA,NA

--- a/tests/testthat/_snaps/hc/censored_2ll.csv
+++ b/tests/testthat/_snaps/hc/censored_2ll.csv
@@ -1,0 +1,2 @@
+dist,proportion,est,se,lcl,ucl,wt,method,nboot,pboot,samples
+average,0.05,1.28005,NA,NA,NA,1,parametric,0,NA,numeric(0)

--- a/tests/testthat/_snaps/hc/censored_5ll.csv
+++ b/tests/testthat/_snaps/hc/censored_5ll.csv
@@ -1,0 +1,2 @@
+dist,proportion,est,se,lcl,ucl,wt,method,nboot,pboot,samples
+average,0.05,1.36598,NA,NA,NA,1,parametric,0,NA,numeric(0)

--- a/tests/testthat/_snaps/hc/censored_ave.csv
+++ b/tests/testthat/_snaps/hc/censored_ave.csv
@@ -1,0 +1,2 @@
+dist,proportion,est,se,lcl,ucl,wt,method,nboot,pboot,samples
+average,0.05,NA,NA,NA,NA,1,parametric,0,NA,numeric(0)

--- a/tests/testthat/_snaps/hc/censored_each.csv
+++ b/tests/testthat/_snaps/hc/censored_each.csv
@@ -1,0 +1,3 @@
+dist,proportion,est,se,lcl,ucl,wt,method,nboot,pboot,samples
+lnorm,0.05,1.31771,NA,NA,NA,NA,parametric,0,NA,numeric(0)
+lnorm_lnorm,0.05,1.35376,NA,NA,NA,NA,parametric,0,NA,numeric(0)

--- a/tests/testthat/test-gof.R
+++ b/tests/testthat/test-gof.R
@@ -16,32 +16,50 @@ test_that("gof", {
   fits <- ssd_fit_dists(ssddata::ccme_boron)
 
   gof_statistic <- ssd_gof(fits)
-  expect_s3_class(gof_statistic, "tbl")
   expect_snapshot_data(gof_statistic, "gof_statistic")
 
   gof <- ssd_gof(fits, pvalue = TRUE)
-  expect_s3_class(gof, "tbl")
   expect_snapshot_data(gof, "gof")
 })
 
-test_that("gof mixture", {
-  fits <- ssd_fit_dists(ssddata::ccme_boron, dists = "llogis_llogis")
-
-  gof_statistic <- ssd_gof(fits)
-  expect_s3_class(gof_statistic, "tbl")
-  expect_snapshot_data(gof_statistic, "gof_statistic_mixture")
-
-  gof <- ssd_gof(fits, pvalue = TRUE)
-  expect_s3_class(gof, "tbl")
-  expect_snapshot_data(gof, "gof_pvalue_mixture")
-})
-
-test_that("gof censored", {
-  skip("error with gof with censored data")
+test_that("gof censored same parameters2", {
   data <- ssddata::ccme_boron
   data$right <- data$Conc
   data$Conc[c(3,6,8)] <- NA
-  fit <- ssd_fit_dists(data, right = "right") 
-  gof <- ssd_gof(fit)
-  expect_snapshot_data(gof, "censored")
+
+  fits <- ssd_fit_dists(data, right = "right", dists = c("llogis", "lnorm"))
+  
+  gof_statistic <- ssd_gof(fits)
+  expect_snapshot_data(gof_statistic, "gof_statistic2")
+  
+  gof <- ssd_gof(fits, pvalue = TRUE)
+  expect_snapshot_data(gof, "gof2")
+})
+
+test_that("gof censored same parameters5", {
+  data <- ssddata::ccme_boron
+  data$right <- data$Conc
+  data$Conc[c(3,6,8)] <- NA
+  
+  fits <- ssd_fit_dists(data, right = "right", dists = c("llogis_llogis", "lnorm_lnorm"))
+  
+  gof_statistic <- ssd_gof(fits)
+  expect_snapshot_data(gof_statistic, "gof_statistic5")
+  
+  gof <- ssd_gof(fits, pvalue = TRUE)
+  expect_snapshot_data(gof, "gof5")
+})
+
+test_that("gof censored same diff parameters", {
+  data <- ssddata::ccme_boron
+  data$right <- data$Conc
+  data$Conc[c(3,6,8)] <- NA
+  
+  fits <- ssd_fit_dists(data, right = "right", dists = c("llogis", "lnorm_lnorm"))
+  
+  gof_statistic <- ssd_gof(fits)
+  expect_snapshot_data(gof_statistic, "gof_statisticn")
+  
+  gof <- ssd_gof(fits, pvalue = TRUE)
+  expect_snapshot_data(gof, "gofn")
 })

--- a/tests/testthat/test-gof.R
+++ b/tests/testthat/test-gof.R
@@ -35,3 +35,13 @@ test_that("gof mixture", {
   expect_s3_class(gof, "tbl")
   expect_snapshot_data(gof, "gof_pvalue_mixture")
 })
+
+test_that("gof censored", {
+  skip("error with gof with censored data")
+  data <- ssddata::ccme_boron
+  data$right <- data$Conc
+  data$Conc[c(3,6,8)] <- NA
+  fit <- ssd_fit_dists(data, right = "right") 
+  gof <- ssd_gof(fit)
+  expect_snapshot_data(gof, "censored")
+})

--- a/tests/testthat/test-hc.R
+++ b/tests/testthat/test-hc.R
@@ -13,12 +13,21 @@
 #    limitations under the License.
 
 test_that("hc", {
-  
   fits <- ssd_fit_dists(ssddata::ccme_boron)
   set.seed(102)
   hc <- ssd_hc(fits, ci = TRUE, nboot = 10, average = FALSE, samples = TRUE)
   expect_s3_class(hc, "tbl")
   expect_snapshot_data(hc, "hc")
+})
+
+test_that("gof censored", {
+  skip("not getting fit with censored data")
+  data <- ssddata::ccme_boron
+  data$right <- data$Conc
+  data$Conc[c(3,6,8)] <- NA
+  fit <- ssd_fit_dists(data, right = "right")
+  hc <- ssd_hc(fit)
+  expect_snapshot_data(hc, "censored")
 })
 
 test_that("ssd_hc list must be named", {

--- a/tests/testthat/test-hc.R
+++ b/tests/testthat/test-hc.R
@@ -20,14 +20,34 @@ test_that("hc", {
   expect_snapshot_data(hc, "hc")
 })
 
-test_that("gof censored", {
-  skip("not getting fit with censored data")
+test_that("hc estimate with censored data same number of 2parameters", {
   data <- ssddata::ccme_boron
   data$right <- data$Conc
   data$Conc[c(3,6,8)] <- NA
-  fit <- ssd_fit_dists(data, right = "right")
+  fit <- ssd_fit_dists(data, right = "right", dists = c("lnorm", "llogis"))
   hc <- ssd_hc(fit)
-  expect_snapshot_data(hc, "censored")
+  expect_snapshot_data(hc, "censored_2ll")
+})
+
+test_that("hc estimate with censored data same number of 5parameters", {
+  data <- ssddata::ccme_boron
+  data$right <- data$Conc
+  data$Conc[c(3,6,8)] <- NA
+  fit <- ssd_fit_dists(data, right = "right", dists = c("lnorm_lnorm", "llogis_llogis"))
+  hc <- ssd_hc(fit)
+  expect_snapshot_data(hc, "censored_5ll")
+})
+
+test_that("hc not estimate with different number of parameters", {
+  data <- ssddata::ccme_boron
+  data$right <- data$Conc
+  data$Conc[c(3,6,8)] <- NA
+  fit <- ssd_fit_dists(data, right = "right", dists = c("lnorm", "lnorm_lnorm"))
+  hc_each <- ssd_hc(fit, average = FALSE)
+  expect_snapshot_data(hc_each, "censored_each")
+  expect_warning(hc_ave <- ssd_hc(fit), 
+                 "Model averaged estimates cannot be calculated for censored data when the distributions have different numbers of parameters.")
+  expect_snapshot_data(hc_ave, "censored_ave")
 })
 
 test_that("ssd_hc list must be named", {


### PR DESCRIPTION
also fixes bug that error in ssd_gof() with censored data.