### PR TITLE
CRAN v2.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ssdtools
 Title: Species Sensitivity Distributions
-Version: 2.0.0.9001
+Version: 2.1.0
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ssdtools
 Title: Species Sensitivity Distributions
-Version: 2.1.0
+Version: 2.1.0.9000
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,23 +2,8 @@
 
 # ssdtools 2.1.0
 
-- Merge pull request #385 from poissonconsulting/dev.
-
-  fix cran and bug if using multi functions with lnorm not included
-
-- Merge pull request #384 from bcgov/cran.
-
-  cran v2.0.0
-
-
-# ssdtools 2.0.0.9001
-
-- Add `ssd_xxmulti_fitdists()` functions to accept object of class fitdists.
-
-
-# ssdtools 2.0.0.9000
-
-- Set `ssd_xxmulti(lnorm.weight = 0)` (instead of 1) to avoid incorrect values with `do.call("ssd_xxmulti", c(..., estimates(fits))` if `fits` does not include the log-normal distribution.
+- Added `ssd_xxmulti_fitdists()` functions to accept object of class `fitdists`.
+- Set `ssd_xxmulti(..., lnorm.weight = 0)` (instead of 1) to avoid incorrect values with `do.call("ssd_xxmulti", c(..., estimates(fits))` if `fits` does not include the log-normal distribution.
 
 
 # ssdtools 2.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
+# ssdtools 2.1.0
+
+- Merge pull request #385 from poissonconsulting/dev.
+
+  fix cran and bug if using multi functions with lnorm not included
+
+- Merge pull request #384 from bcgov/cran.
+
+  cran v2.0.0
+
+
 # ssdtools 2.0.0.9001
 
 - Add `ssd_xxmulti_fitdists()` functions to accept object of class fitdists.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
+# ssdtools 2.1.0.9000
+
+- Same as previous version.
+
+
 # ssdtools 2.1.0
 
 - Added `ssd_xxmulti_fitdists()` functions to accept object of class `fitdists`.

--- a/R/exposure.R
+++ b/R/exposure.R
@@ -4,7 +4,7 @@
 # Energy, the Environment and Water
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compl %>% iance with the License.
+#    you may not use this file except in compliance with the License.
 #    You may obtain a copy of the License at
 #
 #       https://www.apache.org/licenses/LICENSE-2.0

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![R-CMD-check](https://github.com/bcgov/ssdtools/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/bcgov/ssdtools/actions/workflows/R-CMD-check.yaml)
-[![Codecov test coverage](https://codecov.io/gh/bcgov/ssdtools/graph/badge.svg?token=gVKHQQD1Jp)](https://app.codecov.io/gh/bcgov/ssdtools)
+[![Codecov test coverage](https://codecov.io/gh/bcgov/ssdtools/graph/badge.svg)](https://app.codecov.io/gh/bcgov/ssdtools)
 [![CRAN status](https://www.r-pkg.org/badges/version/ssdtools)](https://cran.r-project.org/package=ssdtools)
 ![CRAN downloads](https://cranlogs.r-pkg.org/badges/ssdtools)
 <!-- badges: end -->
@@ -32,10 +32,18 @@ Confidence intervals on hazard concentrations and proportions are produced by bo
 
 ## Installation
 
+### Release
+
 To install the latest release version from [CRAN](https://CRAN.R-project.org/package=ssdtools).
 ```r
 install.packages("ssdtools")
 ```
+
+#### Website
+
+The website for the release version is at <https://bcgov.github.io/ssdtools/>.
+
+### Development
 
 To install the latest development version from [r-universe](https://bcgov.r-universe.dev/ssdtools).
 ```r
@@ -47,6 +55,10 @@ or from [GitHub](https://github.com/bcgov/ssdtools)
 # install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))
 pak::pak("bcgov/ssdtools")
 ```
+
+#### Website
+
+The website for the development version is at <https://bcgov.github.io/ssdtools/dev>.
 
 ## Introduction
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -58,7 +58,7 @@ pak::pak("bcgov/ssdtools")
 
 #### Website
 
-The website for the development version is at <https://bcgov.github.io/ssdtools/dev>.
+The website for the development version is at <https://bcgov.github.io/ssdtools/dev/>.
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![R-CMD-check](https://github.com/bcgov/ssdtools/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/bcgov/ssdtools/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
-coverage](https://codecov.io/gh/bcgov/ssdtools/graph/badge.svg?token=gVKHQQD1Jp)](https://app.codecov.io/gh/bcgov/ssdtools)
+coverage](https://codecov.io/gh/bcgov/ssdtools/graph/badge.svg)](https://app.codecov.io/gh/bcgov/ssdtools)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/ssdtools)](https://cran.r-project.org/package=ssdtools)
 ![CRAN downloads](https://cranlogs.r-pkg.org/badges/ssdtools)
@@ -29,12 +29,21 @@ are produced by bootstrapping.
 
 ## Installation
 
+### Release
+
 To install the latest release version from
 [CRAN](https://CRAN.R-project.org/package=ssdtools).
 
 ``` r
 install.packages("ssdtools")
 ```
+
+#### Website
+
+The website for the release version is at
+<https://bcgov.github.io/ssdtools/>.
+
+### Development
 
 To install the latest development version from
 [r-universe](https://bcgov.r-universe.dev/ssdtools).
@@ -49,6 +58,11 @@ or from [GitHub](https://github.com/bcgov/ssdtools)
 # install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))
 pak::pak("bcgov/ssdtools")
 ```
+
+#### Website
+
+The website for the development version is at
+<https://bcgov.github.io/ssdtools/dev>.
 
 ## Introduction
 
@@ -189,7 +203,7 @@ Distributions in Ecotoxicology. CRC Press.
 
 ## Licensing
 
-Copyright 2018-2024 Province of British Columbia  
+Copyright 2015-2023 Province of British Columbia  
 Copyright 2021 Environment and Climate Change Canada  
 Copyright 2023-2024 Australian Government Department of Climate Change,
 Energy, the Environment and Water

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pak::pak("bcgov/ssdtools")
 #### Website
 
 The website for the development version is at
-<https://bcgov.github.io/ssdtools/dev>.
+<https://bcgov.github.io/ssdtools/dev/>.
 
 ## Introduction
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -12,4 +12,4 @@ The large size of these sub-directories is necessary.
 
 ## CRAN Package Check Results for Package
 
-Fixed noRemap issue.
+Fixed M1mac issue.

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -6,7 +6,7 @@ volume = {19},
 number = {2},
 pages = {508-515},
 keywords = {Risk assessment, Species sensitivity, Bootstrap, Statistics, Sample size},
-doi = {https://doi.org/10.1002/etc.5620190233},
+doi = {10.1002/etc.5620190233},
 url = {https://setac.onlinelibrary.wiley.com/doi/abs/10.1002/etc.5620190233},
 eprint = {https://setac.onlinelibrary.wiley.com/doi/pdf/10.1002/etc.5620190233},
 abstract = {Abstract Species-sensitivity distribution methods assemble single-species toxicity data to predict hazardous concentrations (HCps) affecting a certain percentage (p) of species in a community. The fit of the lognormal model and required number of individual species values were evaluated with 30 published data sets. The increasingly common assumption that a lognormal model best fits these data was not supported. Fifteen data sets failed a formal test of conformity to a lognormal distribution; other distributions often provided better fit to the data than the lognormal distribution. An alternate bootstrap method provided accurate estimates of HCp without the assumption of a specific distribution. Approximate sample sizes producing HC5 estimates with minimal variance ranged from 15 to 55, and had a median of 30 species-sensitivity values. These sample sizes are higher than those suggested in recent regulatory documents. A bootstrap method is recommended that predicts with 95\% confidence the concentration affecting 5\% or fewer species.},
@@ -50,7 +50,8 @@ year = {2000}
 	publisher = {CRC press},
 	author = {Posthuma, L and {Suter II}, GW and Traas, TP},
 	year = {2001},
-	url = {https://www.crcpress.com/Species-Sensitivity-Distributions-in-Ecotoxicology/Posthuma-II-Traas/p/book/9781566705783}
+	url = {https://www.crcpress.com/Species-Sensitivity-Distributions-in-Ecotoxicology/Posthuma-II-Traas/p/book/9781566705783},
+	doi = {10.1002/etc.4373}
 }
 
 @Article{fitdistrplus,
@@ -165,13 +166,6 @@ year = {2000}
 	pages = {293--308}
 }
 
-@article{chapman_2007,
-	title = {Methods of uncertainty analysis},
-	journal={In: A H (ed) EUFRAM Concerted Action to Develop a European Framework for Probabilistic Risk Assessment of the Environmental Impacts of Pesticides, Vol 2, Detailed Reports on Role, Methods, Reporting and Validation},
-	author = {Chapman, PF RM and Hart, A and Roelofs, W and Aldenberg, T and Solomon, K and Tarazona, J LM and Byrne, P and Powley, W and Green, J and Ferson, S and Galicia, H},
-	year = {2007}
-}
-
 @techreport{fox_methodologies_2022,
 	title = {Joint investigation into {statistical} {methodologies} underpinning the {derivation} of {toxicant} {guideline} {values} in {Australia} and {New Zealand}},
 	institution = {Environmetrics Australia and Australian Institute of Marine Science},
@@ -221,9 +215,9 @@ Report prepared for the Department of Climate Change, Energy, the Environment an
 
 @techreport{USEPA2020,
    author = {{US EPA}},
-   title = {Species Sensitivity Distribution (SSD) Toolbox.},
+   title = {Species Sensitivity Distribution (SSD) Toolbox},
    year = {2020},
    publisher = { Center for Computational Toxicology and Exposure, Durham, NC},
-  url = {https://www.epa.gov/chemical-research/species-sensitivity-distribution-ssd-toolbox}
+  url = {https://www.epa.gov/chemical-research/species-sensitivity-distribution-ssd-toolbox},
+  doi = {10.23645/epacomptox.11971392.v2}
 }
-


### PR DESCRIPTION
# ssdtools 2.1.0.9000

- Same as previous version.


# ssdtools 2.1.0

- Added `ssd_xxmulti_fitdists()` functions to accept object of class `fitdists`.
- Set `ssd_xxmulti(..., lnorm.weight = 0)` (instead of 1) to avoid incorrect values with `do.call("ssd_xxmulti", c(..., estimates(fits))` if `fits` does not include the log-normal distribution.
