### PR TITLE
Implement ssd_fit_dists() with right censored data - fixes #207

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ inst/doc
 scripts
 
 /paper/paper.pdf
+
+.vscode
+.github/dependabot.yml
+.devcontainer
+inst/eduard.R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Authors@R: c(
     person("Emilie", "Doussantousse", role = "ctb"),
     person("Nan-Hung", "Hsieh", role = "ctb"),
     person("Florencia", "D'Andrea", role = "ctb"),
+    person("Eduard", "Szöcs", role = "ctb", comment = c(ORCID = "0000-0001-5376-1194")),
     person("Province of British Columbia", role = c("fnd", "cph")),
     person("Environment and Climate Change Canada", role = c("fnd", "cph")),
     person("Australian Government Department of Climate Change, Energy, the Environment and Water", role = c("fnd", "cph"))

--- a/R/fit.R
+++ b/R/fit.R
@@ -220,8 +220,9 @@ ssd_fit_dists <- function(
   data <- process_data(data, left, right, weight)
   attrs <- adjust_data(data, rescale = rescale, reweight = reweight, silent = silent)
 
-  if (any(is.infinite(attrs$data$right))) {
-    err("Distributions cannot currently be fitted to right censored data.")
+  # TODO: Drop this check once implmented for all distributions
+  if (any(is.infinite(attrs$data$right)) && !"lnorm" %in% dists) {
+    err("Currently only the 'lnorm' distribution can be fitted to right-censored data.")
   }
 
   fits <- fits_dists(attrs$data, dists,

--- a/R/fit.R
+++ b/R/fit.R
@@ -220,11 +220,6 @@ ssd_fit_dists <- function(
   data <- process_data(data, left, right, weight)
   attrs <- adjust_data(data, rescale = rescale, reweight = reweight, silent = silent)
 
-  # TODO: Drop this check once implmented for all distributions
-  if (any(is.infinite(attrs$data$right)) && !"lnorm" %in% dists) {
-    err("Currently only the 'lnorm' distribution can be fitted to right-censored data.")
-  }
-
   fits <- fits_dists(attrs$data, dists,
     min_pmix = min_pmix, range_shape1 = range_shape1,
     range_shape2 = range_shape2,

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -53,7 +53,7 @@ fit_tmb <- function(data, dist, min_pmix, range_shape1, range_shape2,
                     control, pars = NULL, hessian = TRUE, ...) {
   # sdist cannot handle Infs very well, turn into NAs
   # TODO: better handle in process_data which sets it to Inf?
-  data_s  <- data
+  data_s <- data
   data_s$right[is.infinite(data_s$right)] <- NA
   pars <- sdist(dist, data_s, pars)
   model <- tmb_model(dist, data, pars = pars)

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -51,7 +51,11 @@ optimize <- function(par, fn, gr, lower, upper, control, hessian) {
 
 fit_tmb <- function(data, dist, min_pmix, range_shape1, range_shape2,
                     control, pars = NULL, hessian = TRUE, ...) {
-  pars <- sdist(dist, data, pars)
+  # sdist cannot handle Infs very well, turn into NAs
+  # TODO: better handle in process_data which sets it to Inf?
+  data_s  <- data
+  data_s$right[is.infinite(data_s$right)] <- NA
+  pars <- sdist(dist, data_s, pars)
   model <- tmb_model(dist, data, pars = pars)
   bounds <- bdist(dist, data, min_pmix, range_shape1, range_shape2)
   # required because model can switch order of parameters

--- a/src/TMB/ll_burrIII3.hpp
+++ b/src/TMB/ll_burrIII3.hpp
@@ -86,7 +86,8 @@ Type ll_burrIII3(objective_function<Type>* obj) // normal with parameters mu and
      if(left(i) < right(i)){   // censored data
         pleft = 0;
         if(left(i)>0){ pleft=1/pow(1+pow(scale/left(i),shape2),shape1);};
-        pright = 1/pow(1+pow(scale/right(i),shape2),shape1);
+        pright = 1;
+        if(isfinite(right(i))){ pright = 1/pow(1+pow(scale/right(i),shape2),shape1);};
         nll -= weight(i)*log(pright-pleft);  // contribution to log-likelihood for censored values
      };
      

--- a/src/TMB/ll_gamma.hpp
+++ b/src/TMB/ll_gamma.hpp
@@ -80,7 +80,8 @@ Type ll_gamma(objective_function<Type>* obj) // normal with parameters mu and lo
      if(left(i) < right(i)){   // censored data
         pleft = 0;
         if(left(i)>0){ pleft=pgamma( left(i), shape, scale );};
-        pright = pgamma( right(i), shape, scale);
+        pright = 1;
+        if(isfinite(right(i))){ pright = pgamma( right(i), shape, scale );};
         nll -= weight(i)*log(pright-pleft);  // contribution to log-likelihood for censored values
      };
      

--- a/src/TMB/ll_gompertz.hpp
+++ b/src/TMB/ll_gompertz.hpp
@@ -85,7 +85,8 @@ Type ll_gompertz(objective_function<Type>* obj) // normal with parameters mu and
      if(left(i) < right(i)){   // censored data
         pleft = 0;
         if(left(i)>0){ pleft=1 - exp(-location/shape * (exp(left(i) * shape) - 1));};
-        pright =1 - exp(-location/shape * (exp(right(i) * shape) - 1));
+        pright = 1;
+        if(isfinite(right(i))){ pright =1 - exp(-location/shape * (exp(right(i) * shape) - 1));};
         nll -= weight(i)*log(pright-pleft);  // contribution to log-likelihood for censored values
      };
      

--- a/src/TMB/ll_invpareto.hpp
+++ b/src/TMB/ll_invpareto.hpp
@@ -94,7 +94,7 @@ Type ll_invpareto(objective_function<Type>* obj) // normal with parameters mu an
         if(left(i)>scale)pleft=1;
         if((left(i)>0) && (left(i)<=scale)){ pleft= pow((left(i)/scale),shape);};  // need the other tail for the inverse
         pright = 1;
-        if(right(i)<=scale) { pright=pow((right(i)/scale),shape);};
+        if(isfinite(right(i)) && right(i)<=scale) { pright=pow((right(i)/scale),shape);};
         nll -= weight(i)*log(pright-pleft);  // contribution to log-likelihood for censored values
      };
      

--- a/src/TMB/ll_lgumbel.hpp
+++ b/src/TMB/ll_lgumbel.hpp
@@ -88,8 +88,11 @@ Type ll_lgumbel(objective_function<Type>* obj) // normal with parameters mu and 
           z = (log(left(i))-locationlog)/scalelog;
           pleft= exp(-exp(-z));
         };
-        z=(log(right(i))-locationlog)/scalelog;
-        pright = exp(-exp(-z));
+        pright = 1;
+        if(isfinite(right(i))){ 
+          z=(log(right(i))-locationlog)/scalelog;
+          pright = exp(-exp(-z));
+        };
         nll -= weight(i)*log(pright-pleft);  // contribution to log-likelihood for censored values
      };
      

--- a/src/TMB/ll_llogis.hpp
+++ b/src/TMB/ll_llogis.hpp
@@ -80,7 +80,8 @@ Type ll_llogis(objective_function<Type>* obj) {
      if(left(i) < right(i)){    // censored values; no builtin function so we code the cdf directly
         pleft = 0;
         if(left(i)>0){ pleft=1/(1+exp(-(log(left(i))-locationlog)/scalelog));};
-        pright =1/(1+exp(-(log(right(i))-locationlog)/scalelog));
+        pright = 1;
+        if(isfinite(right(i))){ pright=1/(1+exp(-(log(right(i))-locationlog)/scalelog));};
         nll -= weight(i)*log(pright-pleft);
      };
      

--- a/src/TMB/ll_llogis_llogis.hpp
+++ b/src/TMB/ll_llogis_llogis.hpp
@@ -93,8 +93,9 @@ Type ll_llogis_llogis(objective_function<Type>* obj) // normal with parameters m
         pleft = 0;
         if(left(i)>0){ pleft=pmix   * 1/(1+exp(-(log(left(i))-locationlog1)/scalelog1))+
                             (1-pmix)* 1/(1+exp(-(log(left(i))-locationlog2)/scalelog2));};
-        pright=pmix    * 1/(1+exp(-(log(right(i))-locationlog1)/scalelog1))+
-                                       (1-pmix)* 1/(1+exp(-(log(right(i))-locationlog2)/scalelog2));
+        pright = 1;
+        if(isfinite(right(i))){ pright=pmix    * 1/(1+exp(-(log(right(i))-locationlog1)/scalelog1))+
+          (1-pmix)* 1/(1+exp(-(log(right(i))-locationlog2)/scalelog2));};
         nll -= weight(i)*log(pright-pleft);
      };
      // mynll(i) = nll;  // for debugging

--- a/src/TMB/ll_lnorm.hpp
+++ b/src/TMB/ll_lnorm.hpp
@@ -81,7 +81,8 @@ Type ll_lnorm(objective_function<Type>* obj) {
      if(left(i) < right(i)){   // censored data
         pleft = 0;
         if(left(i)>0){ pleft=pnorm(log(left(i)), meanlog, sdlog);};
-        pright = pnorm(log(right(i)), meanlog, sdlog);
+        pright = 1;
+        if(isfinite(right(i))){ pright=pnorm(log(right(i)), meanlog, sdlog);};
         nll -= weight(i)*log(pright-pleft);  // contribution to log-likelihood for censored values
      };
      

--- a/src/TMB/ll_lnorm_lnorm.hpp
+++ b/src/TMB/ll_lnorm_lnorm.hpp
@@ -59,8 +59,9 @@ Type ll_lnorm_lnorm(objective_function<Type>* obj) // normal with parameters mu 
         pleft = 0;
         if(left(i)>0){ pleft=pmix * pnorm(log(left(i)), meanlog1, sdlog1)+
                             (1-pmix) * pnorm(log(left(i)), meanlog2, sdlog2);};
-        pright=pmix * pnorm(log(right(i)), meanlog1, sdlog1)+
-                                       (1-pmix)* pnorm(log(right(i)), meanlog2, sdlog2);
+        pright = 1;
+        if(isfinite(right(i))){ pright = pmix * pnorm(log(right(i)), meanlog1, sdlog1)+
+                                  (1-pmix)* pnorm(log(right(i)), meanlog2, sdlog2);};
         nll -= weight(i)*log(pright-pleft);
      };
   };

--- a/src/TMB/ll_weibull.hpp
+++ b/src/TMB/ll_weibull.hpp
@@ -82,7 +82,8 @@ Type ll_weibull(objective_function<Type>* obj) // normal with parameters mu and 
      if(left(i) < right(i)){   // censored data
         pleft = 0;
         if(left(i)>0){ pleft=pweibull( left(i), shape, scale );};
-        pright =pweibull( right(i), shape, scale);
+        pright = 1;
+        if(isfinite(right(i))){ pright = pweibull( right(i), shape, scale);};
         nll -= weight(i)*log(pright-pleft);  // contribution to log-likelihood for censored values
      };
      

--- a/tests/testthat/_snaps/print.md
+++ b/tests/testthat/_snaps/print.md
@@ -29,6 +29,14 @@
     
     Parameters estimated from 28 rows of inconsistently censored data.
 
+# summary fitdists with right censored, rescaled, weighted data
+
+    Distribution 'lnorm'
+      meanlog 0.632182
+      sdlog 1.30302
+    
+    Parameters estimated from 28 rows of inconsistently censored, unequally weighted and rescaled (8.408) data.
+
 # print fitdists with multiple distributions
 
     Distribution 'gamma'

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -333,16 +333,14 @@ test_that("ssd_fit_dists works with right censored data", {
   data$right <- data$Conc
   data$right[1] <- Inf
 
-  expect_error(
-    fits <- ssd_fit_dists(data, dists = "lnorm", right = "right"),
-    "^Distributions cannot currently be fitted to right censored data\\.$"
-  )
+  fits <- ssd_fit_dists(data, dists = "lnorm", right = "right")
 
-  #
-  # tidy <- tidy(fits)
-  #
-  # expect_equal(tidy$est, c(2.54093502870563, 1.27968456496323))
-  # expect_equal(tidy$se, c(0.242558677928804, 0.175719927258761))
+  tidy <- tidy(fits)
+
+  expect_equal(tidy$est, c(2.634609, 1.208644), tolerance = 1e-06) 
+  # mosaic: 2.6 & 1.2
+  expect_equal(tidy$se, c(0.2317194, 0.1634157), tolerance = 1e-06)
+  expect_equal(unname(logLik(fits)), -114.5698) # mosaic: -114.6
 })
 
 test_that("ssd_fit_dists gives same answer for missing versus Inf right", {
@@ -350,26 +348,11 @@ test_that("ssd_fit_dists gives same answer for missing versus Inf right", {
 
   data$right <- data$Conc
   data$right[1] <- Inf
-
-  expect_error(
-    fits <- ssd_fit_dists(data, dists = "lnorm", right = "right"),
-    "^Distributions cannot currently be fitted to right censored data\\.$"
-  )
-
+  fitsInf <- ssd_fit_dists(data, dists = "lnorm", right = "right")
   data$right[1] <- NA
-
-  expect_error(
-    fits <- ssd_fit_dists(data, dists = "lnorm", right = "right"),
-    "^Distributions cannot currently be fitted to right censored data\\.$"
-  )
-
-  # fits0 <- ssd_fit_dists(data, dists = "lnorm", right = "right")
-  #
-  # data$right[1] <- NA
-  #
-  # fitsna <- ssd_fit_dists(data, dists = "lnorm", right = "right")
-  #
-  # expect_equal(tidy(fits0), tidy(fitsna))
+  fitsna <- ssd_fit_dists(data, dists = "lnorm", right = "right")
+  
+  expect_equal(tidy(fitsInf), tidy(fitsna))
 })
 
 test_that("ssd_fit_dists min_pmix at_boundary_ok FALSE", {

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -48,8 +48,8 @@ test_that("summary fitdists with right censored, rescaled, weighted data", {
   data$Mass <- seq_len(nrow(data))
   data$Other <- data$Conc
   data$Other[1] <- Inf
-  expect_error(fits <- ssd_fit_dists(data, right = "Other", weight = "Mass", rescale = TRUE, dists = "lnorm"))
-  # expect_snapshot_output(print(fits))
+  fits <- ssd_fit_dists(data, right = "Other", weight = "Mass", rescale = TRUE, dists = "lnorm")
+  expect_snapshot_output(print(fits))
 })
 
 test_that("print fitdists with multiple distributions", {

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -64,7 +64,16 @@ test_that("summary partiaally right censored", {
   data$right <- data$Conc
   data$right[c(3, 6, 8)] <- NA
 
-  expect_error(ssd_fit_dists(data, dists = "lnorm", right = "right"), "^Distributions cannot currently be fitted to right censored data\\.$")
+  fits <- ssd_fit_dists(data, dists = "lnorm", right = "right")
+  summary <- summary(fits)
+  expect_s3_class(summary, "summary_fitdists")
+  expect_identical(names(summary), c("fits", "censoring", "nrow", "rescaled", "weighted", "unequal", "min_pmix"))
+  expect_identical(summary$censoring, c(NA_real_, NA_real_))
+  expect_identical(summary$nrow, 28L)
+  expect_equal(summary$min_pmix, 0.107142857)
+  expect_identical(summary$rescaled, 1)
+  expect_identical(summary$weighted, 1)
+  expect_identical(summary$unequal, FALSE)
 })
 
 test_that("summary fitdists with multiple dists", {


### PR DESCRIPTION
Fixes #207. actually no big deal...

Units tests have been adapted, cross-checked with mosaic-ssd and are all passing.

Some notes on the changes:
* Stumbled also across https://github.com/bcgov/ssdtools/issues/398, please check how I added the right censoring there. Other distributions should be straight forward.
* The `.gitignore` changes can be also dropped (I use [devcontainers](https://containers.dev/) for my development).
* https://github.com/bcgov/ssdtools/compare/main...eduardszoecs:issue_207?expand=1#diff-7a11962d819a7f3402a8a6468bdeb585a15926854f479f621d47936d4d0952b1R55 is the minimal invasive change. A better place would be `process_data()`? But this is use more often in the code-base...

* The rest keeps as is: e.g. #378 keeps on throwing an error. So right censoring works only with non-parametric bootstraß